### PR TITLE
fix: refresh date on BufEnter and FocusGained

### DIFF
--- a/lua/nvim_relative_date/buffer.lua
+++ b/lua/nvim_relative_date/buffer.lua
@@ -72,7 +72,7 @@ function M.attach(opts)
 		end,
 	})
 
-	vim.api.nvim_create_autocmd("WinScrolled", {
+	vim.api.nvim_create_autocmd({ "WinScrolled", "BufEnter", "FocusGained" }, {
 		group = relative_date_common.augroup,
 		buffer = opts.bufnr,
 		callback = function()


### PR DESCRIPTION
The events should refresh the date notations on a buffer edited over days.